### PR TITLE
Fix /intake error display

### DIFF
--- a/src/containers/LeaderIntake/LeaderIntake.js
+++ b/src/containers/LeaderIntake/LeaderIntake.js
@@ -4,6 +4,7 @@ import Helmet from 'react-helmet'
 import { connect } from 'react-redux'
 import * as intakeActions from '../../redux/modules/leaderIntake'
 import { load as loadClubs } from '../../redux/modules/clubs'
+import { SubmissionError } from 'redux-form'
 import { Card, Header, Heading, LeaderIntakeForm, Link } from '../../components'
 import colors from '../../styles/colors'
 
@@ -37,6 +38,15 @@ class LeaderIntake extends Component {
     status: PropTypes.string
   }
 
+  handleSubmit(values) {
+    const { submit } = this.props
+
+    return submit(values)
+      .catch(error => {
+	throw new SubmissionError(error.errors)
+      })
+  }
+
   componentDidMount() {
     const { loadClubs } = this.props
 
@@ -44,7 +54,7 @@ class LeaderIntake extends Component {
   }
 
   render() {
-    const { submit, status, clubs } = this.props
+    const { status, clubs } = this.props
 
     return (
       <div>
@@ -55,7 +65,7 @@ class LeaderIntake extends Component {
         </Header>
         <Card style={styles.card}>
           <LeaderIntakeForm
-              onSubmit={values => submit(values)}
+              onSubmit={values => this.handleSubmit(values)}
               status={status}
               clubs={clubs}
             />


### PR DESCRIPTION
This PR makes our `/intake` form display server errors inline. The bug was caused by not throwing a `SubmissionError` when we got an API error.

Before:

![recorded](https://cloud.githubusercontent.com/assets/992248/26710015/ed44a8da-470b-11e7-92fc-331509cd274a.gif)

After:

![recorded](https://cloud.githubusercontent.com/assets/992248/26710037/08b61702-470c-11e7-8a18-fa26d975e46b.gif)
